### PR TITLE
可移动按键增加手柄瞄准,不兼容旧版布局的可移动按键

### DIFF
--- a/app/src/main/java/com/limelight/Game.java
+++ b/app/src/main/java/com/limelight/Game.java
@@ -3148,4 +3148,12 @@ public class Game extends Activity implements SurfaceHolder.Callback,
             setupDisplayPosition();
         }
     }
+
+    public StreamView getStreamView() {
+        return streamView;
+    }
+
+    public boolean getHandleMotionEvent(StreamView streamView,MotionEvent event) {
+        return handleMotionEvent(streamView,event);
+    }
 }

--- a/app/src/main/java/com/limelight/PcView.java
+++ b/app/src/main/java/com/limelight/PcView.java
@@ -185,6 +185,7 @@ public class PcView extends Activity implements AdapterFragmentCallbacks {
             } catch (Exception e) {
                 e.printStackTrace();
             }
+
         }).start();
 
         // 设置长按监听

--- a/app/src/main/java/com/limelight/binding/input/advance_setting/element/AnalogStick.java
+++ b/app/src/main/java/com/limelight/binding/input/advance_setting/element/AnalogStick.java
@@ -135,6 +135,11 @@ public class AnalogStick extends Element {
     private float position_stick_x = 0;
     private float position_stick_y = 0;
 
+    private boolean isFirstTouch = true;
+    private float FirstTouchX = 0;
+    private float FirstTouchY = 0;
+
+
     private SuperConfigDatabaseHelper superConfigDatabaseHelper;
     private PageDeviceController pageDeviceController;
     private AnalogStick analogStick;
@@ -367,9 +372,19 @@ public class AnalogStick extends Element {
         // save last click state
         AnalogStick.CLICK_STATE lastClickState = click_state;
 
+        if (isFirstTouch) {
+            isFirstTouch = false;
+            FirstTouchX = event.getX();
+            FirstTouchY = event.getY();
+        }
+
+
         // get absolute way for each axis
-        relative_x = -(radius - event.getX());
-        relative_y = -(radius - event.getY());
+        relative_x = event.getX()-FirstTouchX;
+        relative_y = event.getY()-FirstTouchY;
+
+//        relative_x = -(radius - event.getX());
+//        relative_y = -(radius - event.getY());
 
         // get radius and angel of movement from center
         movement_radius = getMovementRadius(relative_x, relative_y);
@@ -409,6 +424,9 @@ public class AnalogStick extends Element {
             case MotionEvent.ACTION_CANCEL:
             case MotionEvent.ACTION_UP: {
                 setPressed(false);
+                FirstTouchX = 0;
+                FirstTouchY = 0;
+                isFirstTouch = true;
                 break;
             }
         }

--- a/app/src/main/java/com/limelight/preferences/SeekBarPreference.java
+++ b/app/src/main/java/com/limelight/preferences/SeekBarPreference.java
@@ -21,7 +21,6 @@ public class SeekBarPreference extends DialogPreference
 {
     private static final String ANDROID_SCHEMA_URL = "http://schemas.android.com/apk/res/android";
     private static final String SEEKBAR_SCHEMA_URL = "http://schemas.moonlight-stream.com/apk/res/seekbar";
-    private static final String TAG = "SeekBarPreference";
 
     private SeekBar seekBar;
     private TextView valueText;
@@ -36,10 +35,6 @@ public class SeekBarPreference extends DialogPreference
     private final int keyStepSize;
     private final int divisor;
     private int currentValue;
-    
-    // 对数变换参数
-    private static final double LOG_BASE = 10.0;
-    private boolean isLogarithmic = false;
 
     public SeekBarPreference(Context context, AttributeSet attrs) {
         super(context, attrs);
@@ -70,42 +65,6 @@ public class SeekBarPreference extends DialogPreference
         stepSize = attrs.getAttributeIntValue(SEEKBAR_SCHEMA_URL, "step", 1);
         divisor = attrs.getAttributeIntValue(SEEKBAR_SCHEMA_URL, "divisor", 1);
         keyStepSize = attrs.getAttributeIntValue(SEEKBAR_SCHEMA_URL, "keyStep", 0);
-        
-        // 检查是否为码率设置
-        String key = attrs.getAttributeValue(ANDROID_SCHEMA_URL, "key");
-        if (key != null && key.equals(PreferenceConfiguration.BITRATE_PREF_STRING)) {
-            isLogarithmic = true;
-        }
-    }
-    
-    // 将线性滑块值转换为对数刻度值
-    private int linearToLog(int linearValue) {
-        if (linearValue <= minValue) return minValue;
-        
-        // 计算对数比例尺
-        double minLog = Math.log10(minValue);
-        double maxLog = Math.log10(maxValue);
-        double normalizedValue = (linearValue - minValue) / (double)(maxValue - minValue);
-        double logValue = Math.pow(LOG_BASE, minLog + normalizedValue * (maxLog - minLog));
-        
-        // 确保结果在范围内并按步长取整
-        int result = (int) Math.round(logValue);
-        result = Math.max(minValue, Math.min(maxValue, result));
-        return ((result + (stepSize - 1))/stepSize)*stepSize;
-    }
-    
-    // 将对数刻度值转换回线性滑块值
-    private int logToLinear(int logValue) {
-        if (logValue <= minValue) return minValue;
-        
-        // 计算线性比例尺
-        double minLog = Math.log10(minValue);
-        double maxLog = Math.log10(maxValue);
-        double normalizedValue = (Math.log10(logValue) - minLog) / (maxLog - minLog);
-        double linearValue = minValue + normalizedValue * (maxValue - minValue);
-        
-        // 确保结果在范围内
-        return (int) Math.round(linearValue);
     }
 
     @Override
@@ -147,20 +106,14 @@ public class SeekBarPreference extends DialogPreference
                     seekBar.setProgress(roundedValue);
                     return;
                 }
-                
-                // 如果是码率设置，应用对数变换
-                int displayValue = value;
-                if (isLogarithmic) {
-                    displayValue = linearToLog(value);
-                }
 
                 String t;
                 if (divisor != 1) {
-                    float floatValue = displayValue / (float)divisor;
+                    float floatValue = roundedValue / (float)divisor;
                     t = String.format((Locale)null, "%.1f", floatValue);
                 }
                 else {
-                    t = String.valueOf(displayValue);
+                    t = String.valueOf(value);
                 }
                 valueText.setText(suffix == null ? t : t.concat(suffix.length() > 1 ? " "+suffix : suffix));
             }
@@ -182,13 +135,7 @@ public class SeekBarPreference extends DialogPreference
         if (keyStepSize != 0) {
             seekBar.setKeyProgressIncrement(keyStepSize);
         }
-        
-        // 如果是码率设置，将对数值转换为线性值显示
-        if (isLogarithmic && currentValue > 0) {
-            seekBar.setProgress(logToLinear(currentValue));
-        } else {
-            seekBar.setProgress(currentValue);
-        }
+        seekBar.setProgress(currentValue);
 
         return layout;
     }
@@ -200,13 +147,7 @@ public class SeekBarPreference extends DialogPreference
         if (keyStepSize != 0) {
             seekBar.setKeyProgressIncrement(keyStepSize);
         }
-        
-        // 如果是码率设置，将对数值转换为线性值显示
-        if (isLogarithmic && currentValue > 0) {
-            seekBar.setProgress(logToLinear(currentValue));
-        } else {
-            seekBar.setProgress(currentValue);
-        }
+        seekBar.setProgress(currentValue);
     }
 
     @Override
@@ -224,14 +165,9 @@ public class SeekBarPreference extends DialogPreference
     public void setProgress(int progress) {
         this.currentValue = progress;
         if (seekBar != null) {
-            if (isLogarithmic && progress > 0) {
-                seekBar.setProgress(logToLinear(progress));
-            } else {
-                seekBar.setProgress(progress);
-            }
+            seekBar.setProgress(progress);
         }
     }
-    
     public int getProgress() {
         return currentValue;
     }
@@ -245,16 +181,9 @@ public class SeekBarPreference extends DialogPreference
             @Override
             public void onClick(View view) {
                 if (shouldPersist()) {
-                    int valueToSave = seekBar.getProgress();
-                    
-                    // 如果是码率设置，保存对数变换后的值
-                    if (isLogarithmic) {
-                        valueToSave = linearToLog(valueToSave);
-                    }
-                    
-                    currentValue = valueToSave;
-                    persistInt(valueToSave);
-                    callChangeListener(valueToSave);
+                    currentValue = seekBar.getProgress();
+                    persistInt(seekBar.getProgress());
+                    callChangeListener(seekBar.getProgress());
                 }
 
                 getDialog().dismiss();

--- a/app/src/main/java/com/limelight/utils/UiHelper.java
+++ b/app/src/main/java/com/limelight/utils/UiHelper.java
@@ -260,21 +260,12 @@ public class UiHelper {
     }
 
     public static boolean isColorOS() {
-        String manufacturer = android.os.Build.MANUFACTURER.toLowerCase();
-        String model = android.os.Build.MODEL.toLowerCase();
-        String brand = android.os.Build.BRAND.toLowerCase();
+        String manufacturer = android.os.Build.MANUFACTURER;
+        String model = android.os.Build.MODEL;
+        String brand = android.os.Build.BRAND;
 
-        // 检查是否为OPPO、OnePlus或Realme设备（均使用ColorOS）
-        String[] colorOSBrands = {"oppo", "oneplus", "realme"};
-        
-        for (String colorOSBrand : colorOSBrands) {
-            if (manufacturer.contains(colorOSBrand) || 
-                model.contains(colorOSBrand) || 
-                brand.contains(colorOSBrand)) {
-                return true;
-            }
-        }
-        
-        return false;
+        // 通常OPPO手机的制造商、品牌或型号中会包含OPPO或ColorOS等关键字
+        return manufacturer.toLowerCase().contains("oppo") || model.toLowerCase().contains("oppo") || brand.toLowerCase().contains("oppo") ||
+                manufacturer.toLowerCase().contains("coloros") || model.toLowerCase().contains("coloros") || brand.toLowerCase().contains("coloros");
     }
 }

--- a/app/src/main/res/drawable/rounded_corner.xml
+++ b/app/src/main/res/drawable/rounded_corner.xml
@@ -2,5 +2,4 @@
     android:shape="rectangle">
     <solid android:color="#99EDE7F6"/> <!-- 背景颜色 -->
     <corners android:radius="4dp"/> <!-- 圆角半径 -->
-    <stroke android:width="2dp" android:color="#00000000"/> <!-- 默认无边框 -->
 </shape>

--- a/app/src/main/res/layout/page_digital_movable_button.xml
+++ b/app/src/main/res/layout/page_digital_movable_button.xml
@@ -68,6 +68,23 @@
                     android:text="A"
                     android:background="@drawable/enabled_square" />
             </LinearLayout>
+            <LinearLayout
+                android:orientation="horizontal"
+                android:layout_width="match_parent"
+                android:layout_height="40dp"
+                android:layout_marginVertical="5dp">
+                <TextView
+                    android:layout_width="0dp"
+                    android:layout_height="match_parent"
+                    android:gravity="center_vertical"
+                    android:layout_weight="1"
+                    android:text="从屏幕中心传输触摸事件\n否则传输鼠标移动事件"/>
+                <Switch
+                    android:id="@+id/page_digital_movable_button_enable_touch"
+                    android:layout_width="50dp"
+                    android:layout_height="match_parent"
+                    android:checked="true"/>
+            </LinearLayout>
             <com.limelight.binding.input.advance_setting.superpage.NumberSeekbar
                 android:id="@+id/page_digital_movable_button_central_x"
                 android:layout_width="match_parent"

--- a/app/src/main/res/layout/pc_grid_item.xml
+++ b/app/src/main/res/layout/pc_grid_item.xml
@@ -3,7 +3,7 @@
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
-    android:background="@drawable/pc_item_selector">
+    android:background="@drawable/rounded_corner">
     <TextView
         android:id="@+id/grid_text"
         android:layout_width="match_parent"

--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ buildscript {
         google()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:8.9.1'
+        classpath 'com.android.tools.build:gradle:8.1.2'
     }
 }
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.10.2-bin.zip
+distributionUrl=https://mirrors.cloud.tencent.com/gradle/gradle-8.10.2-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
可移动按键增加手柄瞄准,不兼容旧版布局的可移动按键，
会闪退，或者提前把布局中的可移动按键删除，更新app
后再重新添加即可
建议以后加载按键时使用try
摇杆改为相对移动模式但未增加开关
希望相对移动模式和绝对位置增加开关(我没能抽出时间添加)