### PR TITLE
可移动按键增加手柄瞄准,不兼容旧版布局的可移动按键，

### DIFF
--- a/app/src/main/java/com/limelight/Game.java
+++ b/app/src/main/java/com/limelight/Game.java
@@ -3148,4 +3148,12 @@ public class Game extends Activity implements SurfaceHolder.Callback,
             setupDisplayPosition();
         }
     }
+
+    public StreamView getStreamView() {
+        return streamView;
+    }
+
+    public boolean getHandleMotionEvent(StreamView streamView,MotionEvent event) {
+        return handleMotionEvent(streamView,event);
+    }
 }

--- a/app/src/main/java/com/limelight/binding/input/advance_setting/element/AnalogStick.java
+++ b/app/src/main/java/com/limelight/binding/input/advance_setting/element/AnalogStick.java
@@ -135,6 +135,11 @@ public class AnalogStick extends Element {
     private float position_stick_x = 0;
     private float position_stick_y = 0;
 
+    private boolean isFirstTouch = true;
+    private float FirstTouchX = 0;
+    private float FirstTouchY = 0;
+
+
     private SuperConfigDatabaseHelper superConfigDatabaseHelper;
     private PageDeviceController pageDeviceController;
     private AnalogStick analogStick;
@@ -367,9 +372,19 @@ public class AnalogStick extends Element {
         // save last click state
         AnalogStick.CLICK_STATE lastClickState = click_state;
 
+        if (isFirstTouch) {
+            isFirstTouch = false;
+            FirstTouchX = event.getX();
+            FirstTouchY = event.getY();
+        }
+
+
         // get absolute way for each axis
-        relative_x = -(radius - event.getX());
-        relative_y = -(radius - event.getY());
+        relative_x = event.getX()-FirstTouchX;
+        relative_y = event.getY()-FirstTouchY;
+
+//        relative_x = -(radius - event.getX());
+//        relative_y = -(radius - event.getY());
 
         // get radius and angel of movement from center
         movement_radius = getMovementRadius(relative_x, relative_y);
@@ -409,6 +424,9 @@ public class AnalogStick extends Element {
             case MotionEvent.ACTION_CANCEL:
             case MotionEvent.ACTION_UP: {
                 setPressed(false);
+                FirstTouchX = 0;
+                FirstTouchY = 0;
+                isFirstTouch = true;
                 break;
             }
         }

--- a/app/src/main/res/layout/page_digital_movable_button.xml
+++ b/app/src/main/res/layout/page_digital_movable_button.xml
@@ -68,6 +68,23 @@
                     android:text="A"
                     android:background="@drawable/enabled_square" />
             </LinearLayout>
+            <LinearLayout
+                android:orientation="horizontal"
+                android:layout_width="match_parent"
+                android:layout_height="40dp"
+                android:layout_marginVertical="5dp">
+                <TextView
+                    android:layout_width="0dp"
+                    android:layout_height="match_parent"
+                    android:gravity="center_vertical"
+                    android:layout_weight="1"
+                    android:text="从屏幕中心传输触摸事件\n否则传输鼠标移动事件"/>
+                <Switch
+                    android:id="@+id/page_digital_movable_button_enable_touch"
+                    android:layout_width="50dp"
+                    android:layout_height="match_parent"
+                    android:checked="true"/>
+            </LinearLayout>
             <com.limelight.binding.input.advance_setting.superpage.NumberSeekbar
                 android:id="@+id/page_digital_movable_button_central_x"
                 android:layout_width="match_parent"


### PR DESCRIPTION
可移动按键增加手柄瞄准,不兼容旧版布局的可移动按键，
会闪退，或者提前把布局中的可移动按键删除，更新app
后再重新添加即可
建议以后加载按键时使用try
摇杆改为相对移动模式但未增加开关
希望摇杆相对移动模式和绝对位置模式增加开关(我没能抽出时间添加)
![1744044929073](https://github.com/user-attachments/assets/7af1174d-f745-481b-9177-a9636ec8fec7)

